### PR TITLE
例外処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,8 +1,8 @@
 package raisetech.student.management.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -59,21 +59,8 @@ public class StudentController {
    * @return 受講生IDに紐づく受講生の詳細情報
    */
   @GetMapping("/students/detail")
-  public StudentDetail getStudent(@RequestParam @Range(min = 1, max = 1000) int id) {
+  public StudentDetail getStudent(@RequestParam @NotNull int id) {
     return service.searchStudent(id);
-  }
-
-  /**
-   * 存在しないIDをパラメータ指定した場合に例外処理を行うメソッドです。
-   * ResourceNotFoundExceptionがスローされたときに呼び出され、ステータスコード404（NotFound）の例外メッセージを返します。
-   *
-   * @param ex 例外クラス（データが存在しない）
-   * @return 例外メッセージ
-   */
-  @ExceptionHandler(ResourceNotFoundException.class) // ResourceNotFoundExceptionがスローされたときに呼び出す
-  @ResponseStatus(HttpStatus.NOT_FOUND)  // ステータスコードを404に設定
-  public ErrorResponse handleResourceNotFoundException(ResourceNotFoundException ex) {
-    return new ErrorResponse(ex.getMessage());
   }
 
   /**
@@ -100,4 +87,18 @@ public class StudentController {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新処理が成功しました");
   }
+
+  /**
+   * 存在しないIDをパラメータ指定した場合に例外処理を行うメソッドです。
+   * ResourceNotFoundExceptionがスローされたときに呼び出され、ステータスコード404（NotFound）の例外メッセージを返します。
+   *
+   * @param ex 例外クラス（データが存在しない）
+   * @return 例外メッセージ
+   */
+  @ExceptionHandler(ResourceNotFoundException.class) // ResourceNotFoundExceptionがスローされたときに呼び出す
+  @ResponseStatus(HttpStatus.NOT_FOUND)  // ステータスコードを404に設定
+  public ErrorResponse handleResourceNotFoundException(ResourceNotFoundException ex) {
+    return new ErrorResponse(ex.getMessage());
+  }
 }
+

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.model.domain.StudentDetail;
 import raisetech.student.management.model.exception.ErrorResponse;
@@ -59,7 +58,7 @@ public class StudentController {
    * @return 受講生IDに紐づく受講生の詳細情報
    */
   @GetMapping("/students/detail")
-  public StudentDetail getStudent(@RequestParam @NotNull int id) {
+  public StudentDetail getStudent(@RequestParam @NotNull int id) throws ResourceNotFoundException {
     return service.searchStudent(id);
   }
 
@@ -96,9 +95,9 @@ public class StudentController {
    * @return 例外メッセージ
    */
   @ExceptionHandler(ResourceNotFoundException.class) // ResourceNotFoundExceptionがスローされたときに呼び出す
-  @ResponseStatus(HttpStatus.NOT_FOUND)  // ステータスコードを404に設定
-  public ErrorResponse handleResourceNotFoundException(ResourceNotFoundException ex) {
-    return new ErrorResponse(ex.getMessage());
+  public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
+      ResourceNotFoundException ex) {
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
 }
-

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -3,10 +3,8 @@ package raisetech.student.management.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.model.domain.StudentDetail;
-import raisetech.student.management.model.exception.ErrorResponse;
 import raisetech.student.management.model.exception.ResourceNotFoundException;
 import raisetech.student.management.model.services.StudentService;
 
@@ -54,7 +51,7 @@ public class StudentController {
   /**
    * 受講生の詳細情報の検索です。 IDに紐づく任意の受講生の情報を取得します。 存在しないIDをパラメータに指定してリクエストすると、404NotFoundを返します。
    *
-   * @param id 受講生ID（入力チェック：1~1000まで）
+   * @param id 受講生ID
    * @return 受講生IDに紐づく受講生の詳細情報
    */
   @GetMapping("/students/detail")
@@ -87,17 +84,4 @@ public class StudentController {
     return ResponseEntity.ok("更新処理が成功しました");
   }
 
-  /**
-   * 存在しないIDをパラメータ指定した場合に例外処理を行うメソッドです。
-   * ResourceNotFoundExceptionがスローされたときに呼び出され、ステータスコード404（NotFound）の例外メッセージを返します。
-   *
-   * @param ex 例外クラス（データが存在しない）
-   * @return 例外メッセージ
-   */
-  @ExceptionHandler(ResourceNotFoundException.class) // ResourceNotFoundExceptionがスローされたときに呼び出す
-  public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
-      ResourceNotFoundException ex) {
-    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
-  }
 }

--- a/src/main/java/raisetech/student/management/model/data/Student.java
+++ b/src/main/java/raisetech/student/management/model/data/Student.java
@@ -1,5 +1,7 @@
 package raisetech.student.management.model.data;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,14 +13,27 @@ import lombok.Setter;
 public class Student {
 
   private int id;
+
+  @NotBlank
   private String fullname;
+
+  @NotBlank
   private String furigana;
+
   private String nickname;
+
+  @NotBlank
+  @Email
   private String mail;
+
   private String address;
-  private Integer age; // Spring Boot（Java）では、int型フィールドは初期値0となり、Nullが許容されない
-  private Gender gender; //Javaでenum型を取り扱う場合、別途定義する必要がある
+
+  private Integer age;
+
+  private Gender gender;
+
   private String remark;
+
   private boolean deleted;
 
 }

--- a/src/main/java/raisetech/student/management/model/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/model/data/StudentCourse.java
@@ -1,5 +1,6 @@
 package raisetech.student.management.model.data;
 
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,9 +13,14 @@ import lombok.Setter;
 public class StudentCourse {
 
   private int id;
+
   private int studentId;
+
+  @NotBlank
   private String courseName;
+
   private LocalDateTime startDate;
+
   private LocalDateTime endDate;
 
 }

--- a/src/main/java/raisetech/student/management/model/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/model/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.student.management.model.domain;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,10 @@ import raisetech.student.management.model.data.StudentCourse;
 @AllArgsConstructor
 public class StudentDetail {
 
+  @Valid
   private Student student;
+
+  @Valid
   private List<StudentCourse> studentCourses;
 
 }

--- a/src/main/java/raisetech/student/management/model/exception/ErrorResponse.java
+++ b/src/main/java/raisetech/student/management/model/exception/ErrorResponse.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ErrorResponse {
 
+  private int status;
   private String message;
 
 }

--- a/src/main/java/raisetech/student/management/model/exception/ErrorResponse.java
+++ b/src/main/java/raisetech/student/management/model/exception/ErrorResponse.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * 例外やエラーが発生した場合に返すレスポンスを定義するクラスです。 ステータスコードと例外／エラーメッセージを属性として保有しています。
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/raisetech/student/management/model/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/model/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package raisetech.student.management.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * 存在しないIDをパラメータ指定した場合に例外処理を行うメソッドです。（検査例外）
+   * ResourceNotFoundExceptionがスローされたとき、ステータスコード404（NotFound）および指定した例外メッセージを返します。
+   *
+   * @param ex 例外クラス（リソースが存在しない）
+   * @return エラーレスポンス
+   */
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
+      ResourceNotFoundException ex) {
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  /**
+   * 開発者が想定していない例外が発生した場合に共通して実行されるメソッドです。
+   *
+   * @param ex 例外クラス（想定しない例外）
+   * @return エラーレスポンス
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+        "予期せぬエラーが発生しました。");
+    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+}

--- a/src/main/java/raisetech/student/management/model/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/model/exception/GlobalExceptionHandler.java
@@ -22,17 +22,4 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
 
-  /**
-   * 開発者が想定していない例外が発生した場合に共通して実行されるメソッドです。
-   *
-   * @param ex 例外クラス（想定しない例外）
-   * @return エラーレスポンス
-   */
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
-    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
-        "予期せぬエラーが発生しました。");
-    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
-  }
-
 }

--- a/src/main/java/raisetech/student/management/model/exception/ResourceNotFoundException.java
+++ b/src/main/java/raisetech/student/management/model/exception/ResourceNotFoundException.java
@@ -1,5 +1,8 @@
 package raisetech.student.management.model.exception;
 
+/**
+ * リソースが存在しない場合の例外を定義するクラスです。検査例外です。 引数にメッセージを指定すると、例外発生時にメッセージを返します。
+ */
 public class ResourceNotFoundException extends Exception {
 
   public ResourceNotFoundException(String message) {

--- a/src/main/java/raisetech/student/management/model/exception/ResourceNotFoundException.java
+++ b/src/main/java/raisetech/student/management/model/exception/ResourceNotFoundException.java
@@ -1,8 +1,9 @@
 package raisetech.student.management.model.exception;
 
-public class ResourceNotFoundException extends RuntimeException {
+public class ResourceNotFoundException extends Exception {
 
   public ResourceNotFoundException(String message) {
     super(message);
   }
+
 }

--- a/src/main/java/raisetech/student/management/model/services/StudentService.java
+++ b/src/main/java/raisetech/student/management/model/services/StudentService.java
@@ -55,7 +55,7 @@ public class StudentService {
    * @param id 受講生ID
    * @return IDに紐づく受講生の詳細情報
    */
-  public StudentDetail searchStudent(int id) {
+  public StudentDetail searchStudent(int id) throws ResourceNotFoundException {
     Student student = repository.searchStudent(id);
 
     if (student == null) {
@@ -110,7 +110,3 @@ public class StudentService {
     studentDetail.getStudentCourses().forEach(repository::updateStudentCourses);
   }
 }
-
-/**
- * 受講生の詳細情報を検索する際に、存在しない情報を登録する際の初期情報（受講生ID、コース開始日、終了日）を登録するメソッドです。
- */


### PR DESCRIPTION
**新カリキュラム第36回の課題を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要

**◆以下の２点を実施し、動作確認を行いました。**

1. 新規登録処理、更新処理に入力チェックを追加しました。（[8542707](https://github.com/YaraiM/StudentManagementREST/pull/4/commits/85427079aefef88ee01c62588b6b6716494448ee)）

2. ResourceNotFoundExceptionを検査例外として修正した後、例外ハンドラークラスを作成し、例外処理を一元管理できるようにしました。（[7e41451](https://github.com/YaraiM/StudentManagementREST/pull/4/commits/7e414512319844f61926a87080ca976eee92ba89), [236ccd6](https://github.com/YaraiM/StudentManagementREST/pull/4/commits/236ccd6a2afe3babb5b2ce06c9e6b5595a009990), [1506ce6](https://github.com/YaraiM/StudentManagementREST/pull/4/commits/1506ce641dfc7ca9d5c0fb826c9b242fdbc9cecd)）

**◆MySQLで事前に用意したデータテーブルは、以下の通りです**
1.students
<img src="https://github.com/YaraiM/StudentManagementREST/assets/153747182/7f284c5c-9c5d-4a44-ab6e-31965907e02d" width="100%">  

2.students_courses
  <img src="https://github.com/YaraiM/StudentManagementREST/assets/153747182/fe192d45-ce81-48a8-b19a-88f541004190" width="70%">

***
 
## 動作確認
**1. 【入力チェック】新規登録処理や更新処理の際、入力内容に不備があると、処理を中断し、例外を返します。例えば、新規登録処理において、@NotBlankが指定されているStudentオブジェクトのfullname属性を空にしてリクエストすると、ユーザー（Postman）に対して400 BadRequestを返すとともに、開発者（コンソール）には「空白は許可されていません」と返します。**

↓リクエスト情報
~~~
{
    "student": {
        "fullname": "",
        "furigana": "すずきろくろう",
        "nickname": "ロクロー",
        "mail": "suzuki6@google.com",
        "address": "千葉",
        "age": 54,
        "gender": "男性",
        "remark": "新規登録処理の確認"
    },
    "studentCourses": [
        {
            "courseName": "Design"
        },
        {
            "courseName": "Ruby"
        },
        {
            "courseName": "Java"
        }
    ]
}
~~~

↓Postmanに表示されたレスポンス
~~~
{
    "timestamp": "2024-07-03T16:31:08.015+00:00",
    "status": 400,
    "error": "Bad Request",
    "path": "/students/new"
}
~~~

↓コンソールに表示されたメッセージ
![入力チェック_コンソール](https://github.com/YaraiM/StudentManagementREST/assets/153747182/f032f29e-02bc-4f9a-9258-cc31f29cbaa1)


**2. 【例外処理】パスとして/students/detailを指定し、パラメータとして受講生IDを入力してGETリクエストを行うと、指定したIDに応じて以下のように動作します。**

i. 指定した受講生IDがstudentsテーブルに存在する場合は、ユーザー（Postman）に受講生情報をJSON形式で返します。（例えば、「 http://localhost:8080/students/detail?id=5 」）
~~~
{
    "student": {
        "id": 5,
        "fullname": "谷村信二",
        "furigana": "たにむらしんじ",
        "nickname": "たに",
        "mail": "tanimura@google.com",
        "address": "名古屋",
        "age": 45,
        "gender": "その他",
        "remark": null,
        "deleted": false
    },
    "studentCourses": [
        {
            "id": 8,
            "studentId": 5,
            "courseName": "Design",
            "startDate": "2024-04-20T12:00:00",
            "endDate": "2025-04-20T12:00:00"
        }
    ]
}
~~~

ii. 指定した受講生IDがstudentsテーブルにそのIDが存在しない場合は、ステータスコード404（NotFound）および例外メッセージ「受講生ID 「{id}」は存在しません」をユーザー（Postman）に返します。（例えば、「 http://localhost:8080/students/detail?id=20 」）

~~~
{
    "status": 404,
    "message": "受講生ID 「20」は存在しません"
}
~~~