### PR TITLE
StudentControllerの単体テスト作成

### DIFF
--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -22,7 +22,7 @@ class StudentControllerTest {
   private StudentService service;
 
   @Test
-  void 受講生詳細の一覧検索_エンドポイントでサービスの処理が適切に呼び出されていること()
+  void 受講生詳細の一覧検索_エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること()
       throws Exception {
     // 実行と検証
     mockMvc.perform(MockMvcRequestBuilders.get("/students"))
@@ -31,4 +31,14 @@ class StudentControllerTest {
     verify(service, times(1)).searchStudentList();
   }
 
+  @Test
+  void 過去の受講生詳細の一覧検索_エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること()
+      throws Exception {
+    // 実行と検証
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/past"))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).searchPastStudentList();
+  }
+  
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -3,23 +3,28 @@ package raisetech.student.management.controller;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static raisetech.student.management.model.data.Gender.男性;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.student.management.model.data.Student;
 import raisetech.student.management.model.data.StudentCourse;
@@ -38,6 +43,28 @@ class StudentControllerTest {
 
   @MockBean
   private StudentService service;
+
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  /**
+   * テスト用にStudentDetailオブジェクトを作成するメソッドです。受講生IDのみ入力したインスタンスが生成されます。
+   *
+   * @param id 受講生ID
+   * @return 受講生の詳細情報
+   */
+  private static StudentDetail createTestStudentDetail(int id) {
+    Student student = new Student();
+    student.setId(id);
+
+    StudentCourse studentCourse1 = new StudentCourse();
+    StudentCourse studentCourse2 = new StudentCourse();
+    studentCourse1.setStudentId(student.getId());
+    studentCourse2.setStudentId(student.getId());
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(studentCourse1, studentCourse2));
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourses);
+    return studentDetail;
+  }
 
   @Test
   void 受講生詳細の一覧検索_エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること()
@@ -64,21 +91,11 @@ class StudentControllerTest {
       throws Exception {
     // 事前準備
     int id = 666;
-    Student student = new Student();
-    student.setId(id);
-
-    StudentCourse studentCourse1 = new StudentCourse();
-    StudentCourse studentCourse2 = new StudentCourse();
-    studentCourse1.setStudentId(student.getId());
-    studentCourse2.setStudentId(student.getId());
-    List<StudentCourse> studentCourses = new ArrayList<>(List.of(studentCourse1, studentCourse2));
-
-    StudentDetail studentDetail = new StudentDetail(student, studentCourses);
+    StudentDetail studentDetail = createTestStudentDetail(id);
     when(service.searchStudent(id)).thenReturn(studentDetail);
 
     // 実行と検証
-    ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/students/detail")
-            .param("id", String.valueOf(id)))
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/detail").param("id", String.valueOf(id)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.student.id").value(id))
@@ -107,6 +124,110 @@ class StudentControllerTest {
             result.getResolvedException().getMessage()));
 
     verify(service, times(1)).searchStudent(id);
+  }
+
+  @Test
+  void 受講生の新規登録_エンドポイントでサービスの処理が適切に呼び出されリクエスト情報に基づくstudentDetailが返ってくること()
+      throws Exception {
+    // 事前準備
+    int id = 666;
+    StudentDetail studentDetail = createTestStudentDetail(id);
+
+    studentDetail.getStudent().setFullname("田中昭三");
+    studentDetail.getStudent().setFurigana("たなかしょうぞう");
+    studentDetail.getStudent().setNickname("ショーゾー");
+    studentDetail.getStudent().setMail("shozo@example.com");
+    studentDetail.getStudent().setAddress("東京");
+    studentDetail.getStudent().setAge(55);
+    studentDetail.getStudent().setGender(男性);
+    studentDetail.getStudent().setRemark("新規登録のテストです");
+    studentDetail.getStudent().setDeleted(false);
+
+    studentDetail.getStudentCourses().get(0).setCourseName("Java");
+    studentDetail.getStudentCourses().get(1).setCourseName("Ruby");
+
+    when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
+
+    String jsonRequest = objectMapper.writeValueAsString(studentDetail);
+
+    // 実行と検証
+    mockMvc.perform(MockMvcRequestBuilders.post("/students/new")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonRequest))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.student.id").value(id))
+        .andExpect(jsonPath("$.student.fullname").value("田中昭三"))
+        .andExpect(jsonPath("$.student.furigana").value("たなかしょうぞう"))
+        .andExpect(jsonPath("$.student.nickname").value("ショーゾー"))
+        .andExpect(jsonPath("$.student.mail").value("shozo@example.com"))
+        .andExpect(jsonPath("$.student.address").value("東京"))
+        .andExpect(jsonPath("$.student.age").value(55))
+        .andExpect(jsonPath("$.student.gender").value("男性"))
+        .andExpect(jsonPath("$.student.remark").value("新規登録のテストです"))
+        .andExpect(jsonPath("$.student.deleted").value(false))
+        .andExpect(jsonPath("$.studentCourses", hasSize(2)))
+        .andExpect(jsonPath("$.studentCourses[0].studentId").value(id))
+        .andExpect(jsonPath("$.studentCourses[0].courseName").value("Java"))
+        .andExpect(jsonPath("$.studentCourses[1].studentId").value(id))
+        .andExpect(jsonPath("$.studentCourses[1].courseName").value("Ruby"));
+
+    verify(service, times(1)).registerStudent(any(StudentDetail.class));
+
+  }
+
+  @Test
+  void 入力チェック_リクエスト可能な情報がすべて適切な場合に入力チェックがかからないこと()
+      throws Exception {
+    // 事前準備
+    int id = 666;
+    StudentDetail studentDetail = createTestStudentDetail(id);
+
+    studentDetail.getStudent().setFullname("田中昭三");
+    studentDetail.getStudent().setFurigana("たなかしょうぞう");
+    studentDetail.getStudent().setNickname("ショーゾー");
+    studentDetail.getStudent().setMail("shozo@example.com");
+    studentDetail.getStudent().setAddress("東京");
+    studentDetail.getStudent().setAge(55);
+    studentDetail.getStudent().setGender(男性);
+    studentDetail.getStudent().setRemark("新規登録のテストです");
+    studentDetail.getStudent().setDeleted(false);
+
+    studentDetail.getStudentCourses().get(0).setCourseName("Java");
+    studentDetail.getStudentCourses().get(1).setCourseName("Ruby");
+
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(studentDetail);
+
+    // 検証
+    assertEquals(0, violations.size());
+
+  }
+
+  @Test
+  void 入力チェック_リクエスト可能な情報のうち入力値の指定がある項目が不適切な場合に入力チェックがかかること()
+      throws Exception {
+    // 事前準備
+    int id = 666;
+    StudentDetail studentDetail = createTestStudentDetail(id);
+
+    studentDetail.getStudent().setFullname(""); // fullnameは空白を許容しない
+    studentDetail.getStudent().setFurigana(""); // fuliganaは空白を許容しない
+    studentDetail.getStudent().setNickname("ショーゾー");
+    studentDetail.getStudent().setMail("shozo&example.com"); // mailはメールアドレス以外の入力値を許容しない
+    studentDetail.getStudent().setAddress("東京");
+    studentDetail.getStudent().setAge(55);
+    studentDetail.getStudent().setGender(男性);
+    studentDetail.getStudent().setRemark("新規登録のテストです");
+    studentDetail.getStudent().setDeleted(false);
+
+    studentDetail.getStudentCourses().get(0).setCourseName(""); // courseNameは空白を許容しない
+    studentDetail.getStudentCourses().get(1).setCourseName(""); // courseNameは空白を許容しない
+
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(studentDetail);
+
+    // 検証
+    assertEquals(5, violations.size());
+
   }
 
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -1,15 +1,30 @@
 package raisetech.student.management.controller;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.exception.ResourceNotFoundException;
 import raisetech.student.management.model.services.StudentService;
 
 @WebMvcTest(StudentController.class) //Spring MVCのうち、Web層（特にコントローラ層）の単体テストに使用される
@@ -17,6 +32,9 @@ class StudentControllerTest {
 
   @Autowired
   MockMvc mockMvc; //Spring MVCのエンドポイントをテストするためのモックオブジェクト
+
+  @Autowired
+  private ObjectMapper objectMapper; // オブジェクトをJSON文字列に変換するためのオブジェクト
 
   @MockBean
   private StudentService service;
@@ -40,5 +58,55 @@ class StudentControllerTest {
 
     verify(service, times(1)).searchPastStudentList();
   }
-  
+
+  @Test
+  void 受講生詳細の検索_正常系_存在する受講生IDを指定したときにエンドポイントでサービスの処理が適切に呼び出され指定したIDに紐づくstudentDetailが返ってくること()
+      throws Exception {
+    // 事前準備
+    int id = 666;
+    Student student = new Student();
+    student.setId(id);
+
+    StudentCourse studentCourse1 = new StudentCourse();
+    StudentCourse studentCourse2 = new StudentCourse();
+    studentCourse1.setStudentId(student.getId());
+    studentCourse2.setStudentId(student.getId());
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(studentCourse1, studentCourse2));
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourses);
+    when(service.searchStudent(id)).thenReturn(studentDetail);
+
+    // 実行と検証
+    ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/students/detail")
+            .param("id", String.valueOf(id)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.student.id").value(id))
+        .andExpect(jsonPath("$.studentCourses", hasSize(2)))
+        .andExpect(jsonPath("$.studentCourses[0].studentId").value(id))
+        .andExpect(jsonPath("$.studentCourses[1].studentId").value(id));
+
+    verify(service, times(1)).searchStudent(id);
+  }
+
+  @Test
+  void 受講生詳細の検索_異常系_存在しない受講生IDを指定したときに例外がスローされること()
+      throws Exception {
+    // 事前準備
+    int id = 999;
+    when(service.searchStudent(id)).thenThrow(
+        new ResourceNotFoundException("受講生ID 「" + id + "」は存在しません"));
+
+    // 実行と検証
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/detail")
+            .param("id", String.valueOf(id)))
+        .andExpect(status().isNotFound())
+        .andExpect(result -> assertTrue(
+            result.getResolvedException() instanceof ResourceNotFoundException))
+        .andExpect(result -> assertEquals("受講生ID 「" + id + "」は存在しません",
+            result.getResolvedException().getMessage()));
+
+    verify(service, times(1)).searchStudent(id);
+  }
+
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -173,6 +174,41 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.studentCourses[1].courseName").value("Ruby"));
 
     verify(service, times(1)).registerStudent(any(StudentDetail.class));
+
+  }
+
+  @Test
+  void 受講生の更新_エンドポイントでサービスの処理が適切に呼び出されリクエスト情報に基づくstudentDetailが返ってくること()
+      throws Exception {
+    // 事前準備
+    int id = 666;
+    StudentDetail studentDetail = createTestStudentDetail(id);
+
+    studentDetail.getStudent().setFullname("田中昭三");
+    studentDetail.getStudent().setFurigana("たなかしょうぞう");
+    studentDetail.getStudent().setNickname("ショーゾー");
+    studentDetail.getStudent().setMail("shozo@example.com");
+    studentDetail.getStudent().setAddress("東京");
+    studentDetail.getStudent().setAge(56);
+    studentDetail.getStudent().setGender(男性);
+    studentDetail.getStudent().setRemark("更新のテストです。年齢を56に、deletedをtrueにしています。");
+    studentDetail.getStudent().setDeleted(true);
+
+    studentDetail.getStudentCourses().get(0).setCourseName("Java");
+    studentDetail.getStudentCourses().get(1).setCourseName("Ruby");
+
+    doNothing().when(service).updateStudent(any(StudentDetail.class));
+
+    String jsonRequest = objectMapper.writeValueAsString(studentDetail);
+
+    // 実行と検証
+    mockMvc.perform(MockMvcRequestBuilders.put("/students/update")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonRequest))
+        .andExpect(status().isOk())
+        .andExpect(content().string("更新処理が成功しました"));
+
+    verify(service, times(1)).updateStudent(any(StudentDetail.class));
 
   }
 

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -1,0 +1,34 @@
+package raisetech.student.management.controller;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import raisetech.student.management.model.services.StudentService;
+
+@WebMvcTest(StudentController.class) //Spring MVCのうち、Web層（特にコントローラ層）の単体テストに使用される
+class StudentControllerTest {
+
+  @Autowired
+  MockMvc mockMvc; //Spring MVCのエンドポイントをテストするためのモックオブジェクト
+
+  @MockBean
+  private StudentService service;
+
+  @Test
+  void 受講生詳細の一覧検索_エンドポイントでサービスの処理が適切に呼び出されていること()
+      throws Exception {
+    // 実行と検証
+    mockMvc.perform(MockMvcRequestBuilders.get("/students"))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).searchStudentList();
+  }
+
+}

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -178,7 +178,7 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生の更新_エンドポイントでサービスの処理が適切に呼び出されリクエスト情報に基づくstudentDetailが返ってくること()
+  void 受講生の更新_エンドポイントでサービスの処理が適切に呼び出され_更新処理が成功しました_というメッセージが返ってくること()
       throws Exception {
     // 事前準備
     int id = 666;


### PR DESCRIPTION
**新カリキュラム第41回の課題を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要

**◆StudentControllerの単体テストを作成し、テスト成功を確認しました。テスト対象のパスとテストで確認したことは以下の通りです。**
1. /students（受講生一覧検索）
    - エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること
2. /students/past（過去の受講生一覧検索）
    - エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること
3. /students/detail（受講生の詳細検索）
    - 正常系_存在する受講生IDを指定したときにエンドポイントでサービスの処理が適切に呼び出され指定したIDに紐づくstudentDetailが返ってくること
    - 異常系__存在しない受講生IDを指定したときに例外がスローされること
4. /students/new（受講生の新規登録）
    - エンドポイントでサービスの処理が適切に呼び出されリクエスト情報に基づくstudentDetailが返ってくること
5. /students/update（受講生の更新）
    - 受講生の更新_エンドポイントでサービスの処理が適切に呼び出され「更新処理が成功しました」というメッセージが返ってくること

**◆リクエスト情報の入力チェックに関するテストも行いました。**

***
 
## テスト結果

1. /students（受講生一覧検索）
    - エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること
    ![students](https://github.com/user-attachments/assets/374e8def-e204-4de7-8408-9bb639754c3f)

2. /students/past（過去の受講生一覧検索）
    - エンドポイントでサービスの処理が適切に呼び出されて処理成功のレスポンスが返ってくること
    ![students_past](https://github.com/user-attachments/assets/9a01fed2-a9d4-4998-976a-d5290d9400a8)


3. /students/detail（受講生の詳細検索）
    - 正常系_存在する受講生IDを指定したときにエンドポイントでサービスの処理が適切に呼び出され指定したIDに紐づくstudentDetailが返ってくること
    ![students_detail_ok](https://github.com/user-attachments/assets/8e441bcb-2052-473a-a5d2-775ce1b1d049)

    - 異常系__存在しない受講生IDを指定したときに例外がスローされること
    ![students_detail_ng](https://github.com/user-attachments/assets/9ab45d22-6c46-49c9-8fba-a08fc7b03c0e)


4. /students/new（受講生の新規登録）
    - エンドポイントでサービスの処理が適切に呼び出されリクエスト情報に基づくstudentDetailが返ってくること
    ![students_new](https://github.com/user-attachments/assets/56912d87-051e-4466-ba22-15f538f272c2)

5. /students/update（受講生の更新）
    - 受講生の更新_エンドポイントでサービスの処理が適切に呼び出され「更新処理が成功しました」というメッセージが返ってくること
    ![students_update](https://github.com/user-attachments/assets/63e2f14a-312f-4e31-a81e-9150ce0c88b5)

6. 入力チェックに関するテスト
    - リクエスト可能な情報がすべて適切な場合に入力チェックがかからないこと
    ![validation_ok](https://github.com/user-attachments/assets/16165acb-cc2a-4991-98fb-9bcd5db32b1a)

    - リクエスト可能な情報のうち入力値の指定がある項目が不適切な場合に入力チェックがかかること
    ![validation_ng](https://github.com/user-attachments/assets/1e6e4ca5-5d8d-421d-9d3a-51059766e85c)
